### PR TITLE
(Lv2) 멤버 테이블 별도로 생성

### DIFF
--- a/sql/member_ddl.sql
+++ b/sql/member_ddl.sql
@@ -1,0 +1,10 @@
+CREATE TABLE member
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name       VARCHAR(255) NOT NULL,
+    email      VARCHAR(255) NOT NULL UNIQUE,
+    password   VARCHAR(255) NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT unique_email UNIQUE (email) -- 이메일을 유니크 제약조건으로 설정
+);

--- a/sql/member_insert.sql
+++ b/sql/member_insert.sql
@@ -1,0 +1,6 @@
+INSERT INTO member (name, password, email)
+VALUES ('John Doe', 'password123', 'aa@aa.aa'),
+       ('Jane Smith', 'password456', 'bb@bb.bb'),
+       ('Alice Johnson', 'password789', 'cc@cc.cc'),
+       ('Bob Brown', 'password101', 'dd@dd.dd'),
+       ('Charlie Davis', 'password102', 'ee@ee.ee');

--- a/sql/member_select-all.sql
+++ b/sql/member_select-all.sql
@@ -1,0 +1,2 @@
+SELECT *
+FROM member;

--- a/sql/schedule_ddl.sql
+++ b/sql/schedule_ddl.sql
@@ -1,0 +1,9 @@
+CREATE TABLE schedule
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id  BIGINT NOT NULL,
+    content    TEXT   NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_member FOREIGN KEY (member_id) REFERENCES member (id) -- Member 테이블 참조
+);

--- a/sql/schedule_select-all.sql
+++ b/sql/schedule_select-all.sql
@@ -1,0 +1,2 @@
+SELECT *
+FROM schedule;

--- a/src/main/java/yeim/scheduler/SchedulerApplication.java
+++ b/src/main/java/yeim/scheduler/SchedulerApplication.java
@@ -2,11 +2,17 @@ package yeim.scheduler;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+import yeim.scheduler.member.domain.Member;
+import yeim.scheduler.member.infrastructure.MemberRepository;
 
 @SpringBootApplication
 public class SchedulerApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(SchedulerApplication.class, args);
+		ApplicationContext ctx = SpringApplication.run(SchedulerApplication.class, args);
+		MemberRepository memberRepository = ctx.getBean(MemberRepository.class);
+		memberRepository.create(new Member(null, "yeim", "aaa@aaa.aaa", "1234", null, null));
+		memberRepository.create(new Member(null, "hello", "bbb@bbb.bbb", "1234", null, null));
 	}
 }

--- a/src/main/java/yeim/scheduler/SchedulerApplication.java
+++ b/src/main/java/yeim/scheduler/SchedulerApplication.java
@@ -2,17 +2,11 @@ package yeim.scheduler;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.ApplicationContext;
-import yeim.scheduler.member.domain.Member;
-import yeim.scheduler.member.infrastructure.MemberRepository;
 
 @SpringBootApplication
 public class SchedulerApplication {
 
 	public static void main(String[] args) {
-		ApplicationContext ctx = SpringApplication.run(SchedulerApplication.class, args);
-		MemberRepository memberRepository = ctx.getBean(MemberRepository.class);
-		memberRepository.create(new Member(null, "yeim", "aaa@aaa.aaa", "1234", null, null));
-		memberRepository.create(new Member(null, "hello", "bbb@bbb.bbb", "1234", null, null));
+		SpringApplication.run(SchedulerApplication.class, args);
 	}
 }

--- a/src/main/java/yeim/scheduler/member/domain/Member.java
+++ b/src/main/java/yeim/scheduler/member/domain/Member.java
@@ -1,0 +1,23 @@
+package yeim.scheduler.member.domain;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@AllArgsConstructor
+public class Member {
+
+	@Setter
+	private Long id;
+	private String name;
+	private String email;
+	private String password;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+
+	public boolean verifyPassword(String password) {
+		return this.password.equals(password);
+	}
+}

--- a/src/main/java/yeim/scheduler/member/infrastructure/JdbcTemplateMemberRepository.java
+++ b/src/main/java/yeim/scheduler/member/infrastructure/JdbcTemplateMemberRepository.java
@@ -1,0 +1,77 @@
+package yeim.scheduler.member.infrastructure;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+import yeim.scheduler.member.domain.Member;
+
+@Repository
+@Primary
+public class JdbcTemplateMemberRepository implements MemberRepository {
+
+	private final JdbcTemplate template;
+
+	public JdbcTemplateMemberRepository(DataSource dataSource) {
+		this.template = new JdbcTemplate(dataSource);
+	}
+
+	@Override
+	public Member create(Member member) {
+		String sql = """
+				INSERT INTO member (name, email, password, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?)
+			""";
+		KeyHolder keyHolder = new GeneratedKeyHolder();
+		template.update(connection -> {
+			PreparedStatement ps = connection.prepareStatement(sql, new String[]{"id"});
+			ps.setString(1, member.getName());
+			ps.setString(2, member.getEmail());
+			ps.setString(3, member.getPassword());
+			ps.setString(4, member.getCreatedAt().toString());
+			ps.setString(5, member.getUpdatedAt().toString());
+			return ps;
+		}, keyHolder);
+
+		long key = keyHolder.getKey().longValue();
+		member.setId(key);
+		return member;
+	}
+
+	@Override
+	public List<Member> findAll() {
+		String sql = """
+			SELECT id, name, email, password, created_at, updated_at
+			FROM member
+			""";
+		return template.query(sql, memberRowMapper());
+	}
+
+	@Override
+	public Optional<Member> findById(Long id) {
+		String sql = """
+			SELECT id, name, email, password, created_at, updated_at
+			FROM member
+			WHERE id = ?
+			""";
+		Member member = template.queryForObject(sql, memberRowMapper(), id);
+		return Optional.ofNullable(member);
+	}
+
+	private RowMapper<Member> memberRowMapper() {
+		return ((rs, rowNum) -> new Member(
+			rs.getLong("id"),
+			rs.getString("name"),
+			rs.getString("email"),
+			rs.getString("password"),
+			rs.getTimestamp("created_at").toLocalDateTime(),
+			rs.getTimestamp("updated_at").toLocalDateTime()
+		));
+	}
+}

--- a/src/main/java/yeim/scheduler/member/infrastructure/MemberRepository.java
+++ b/src/main/java/yeim/scheduler/member/infrastructure/MemberRepository.java
@@ -1,0 +1,14 @@
+package yeim.scheduler.member.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+import yeim.scheduler.member.domain.Member;
+
+public interface MemberRepository {
+
+	Member create(Member member);
+
+	List<Member> findAll();
+
+	Optional<Member> findById(Long id);
+}

--- a/src/main/java/yeim/scheduler/member/infrastructure/MemoryMemberRepository.java
+++ b/src/main/java/yeim/scheduler/member/infrastructure/MemoryMemberRepository.java
@@ -1,0 +1,33 @@
+package yeim.scheduler.member.infrastructure;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.stereotype.Repository;
+import yeim.scheduler.member.domain.Member;
+
+@Repository
+public class MemoryMemberRepository implements MemberRepository {
+
+	private final ConcurrentHashMap<Long, Member> store = new ConcurrentHashMap<>();
+	private final AtomicLong sequence = new AtomicLong(0);
+
+	@Override
+	public Member create(Member member) {
+		member.setId(sequence.incrementAndGet());
+		store.put(member.getId(), member);
+		return member;
+	}
+
+	@Override
+	public List<Member> findAll() {
+		return new ArrayList<>(store.values());
+	}
+
+	@Override
+	public Optional<Member> findById(Long id) {
+		return Optional.ofNullable(store.get(id));
+	}
+}

--- a/src/main/java/yeim/scheduler/schedule/controller/ApiScheduleController.java
+++ b/src/main/java/yeim/scheduler/schedule/controller/ApiScheduleController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import yeim.scheduler.schedule.domain.Schedule;
 import yeim.scheduler.schedule.domain.ScheduleCreateRequest;
@@ -45,8 +46,9 @@ public class ApiScheduleController {
 	}
 
 	@PostMapping
-	public ResponseEntity<Void> createSchedule(@RequestBody ScheduleCreateRequest request) {
-		Schedule createdSchedule = scheduleService.createSchedule(request);
+	public ResponseEntity<Void> createSchedule(@RequestParam Long memberId,
+		@RequestBody ScheduleCreateRequest request) {
+		Schedule createdSchedule = scheduleService.createSchedule(memberId, request);
 
 		return ResponseEntity
 			.created(URI.create("/api/schedules/" + createdSchedule.getId()))

--- a/src/main/java/yeim/scheduler/schedule/domain/Schedule.java
+++ b/src/main/java/yeim/scheduler/schedule/domain/Schedule.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import yeim.scheduler.member.domain.Member;
 
 @Getter
 @AllArgsConstructor
@@ -11,18 +12,16 @@ public class Schedule {
 
 	@Setter
 	private Long id;
-	private String author;
+	private Member member;
 	private String content;
-	private String password;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 
-	public static Schedule from(ScheduleCreateRequest request) {
+	public static Schedule from(Member member, ScheduleCreateRequest request) {
 		return new Schedule(
 			null,
-			request.getAuthor(),
+			member,
 			request.getContent(),
-			request.getPassword(),
 			LocalDateTime.now(),
 			LocalDateTime.now()
 		);
@@ -31,15 +30,10 @@ public class Schedule {
 	public Schedule update(ScheduleUpdateRequest request) {
 		return new Schedule(
 			id,
-			author,
+			member,
 			request.getContent(),
-			request.getPassword(),
 			createdAt,
 			LocalDateTime.now()
 		);
-	}
-
-	public boolean verifyPassword(String password) {
-		return this.password.equals(password);
 	}
 }

--- a/src/main/java/yeim/scheduler/schedule/domain/ScheduleCreateRequest.java
+++ b/src/main/java/yeim/scheduler/schedule/domain/ScheduleCreateRequest.java
@@ -7,7 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ScheduleCreateRequest {
 
-	private String author;
 	private String content;
-	private String password;
 }

--- a/src/main/java/yeim/scheduler/schedule/domain/ScheduleResponse.java
+++ b/src/main/java/yeim/scheduler/schedule/domain/ScheduleResponse.java
@@ -17,7 +17,7 @@ public class ScheduleResponse {
 	public static ScheduleResponse from(Schedule schedule) {
 		return new ScheduleResponse(
 			schedule.getId(),
-			schedule.getAuthor(),
+			schedule.getMember().getName(),
 			schedule.getContent(),
 			schedule.getCreatedAt(),
 			schedule.getUpdatedAt()

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Schedule Management</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<section id="main">
+</section>
+<script src="js/main.js" type="module"></script>
+</body>
+</html>

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -1,0 +1,6 @@
+import * as Schedule from './schedule/eventHandler.js';
+
+document.addEventListener('DOMContentLoaded', function () {
+  const $main = document.getElementById("main");
+  Schedule.init($main);
+});

--- a/src/main/resources/static/js/schedule/api.js
+++ b/src/main/resources/static/js/schedule/api.js
@@ -1,0 +1,61 @@
+export async function getSchedules() {
+  const response = await fetch('/api/schedules', {
+    method: 'GET'
+  });
+  if (!response.ok) {
+    throw new Error('Failed to fetch schedules');
+  }
+  return response.json();
+}
+
+export async function getScheduleById(id) {
+  const response = await fetch(`/api/schedules/${id}`, {
+    method: 'GET'
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch schedule with ID ${id}`);
+  }
+  return response.json();
+}
+
+export async function createSchedule(memberId, scheduleData) {
+  const url = `/api/schedules?memberId=${encodeURIComponent(memberId)}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(scheduleData)
+  });
+  if (!response.ok) {
+    throw new Error('Failed to create schedule');
+  }
+}
+
+export async function updateSchedule(id, scheduleData) {
+  const response = await fetch(`/api/schedules/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(scheduleData)
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to update schedule with ID ${id}`);
+  }
+  return response.json();
+}
+
+export async function deleteSchedule(id, scheduleData) {
+  const response = await fetch(`/api/schedules/${id}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(scheduleData)
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to delete schedule with ID ${id}`);
+  }
+  return response;
+}

--- a/src/main/resources/static/js/schedule/eventHandler.js
+++ b/src/main/resources/static/js/schedule/eventHandler.js
@@ -1,0 +1,83 @@
+import {
+  renderAllSchedules,
+  renderCreateScheduleForm,
+  renderEditScheduleForm,
+  renderViewSchedule
+} from './render.js';
+import {
+  createSchedule,
+  deleteSchedule,
+  getScheduleById,
+  getSchedules,
+  updateSchedule
+} from './api.js';
+
+export function init($main) {
+  const $target = document.createElement("div");
+  $target.setAttribute("id", "schedule");
+  $target.addEventListener('click',
+      async (event) => {
+        const action = event.target.dataset.action;
+        const scheduleId = event.target.closest('.schedule-item')?.dataset.id;
+
+        if (action === 'view' && scheduleId) {
+          await viewSchedule(scheduleId);
+        } else if (action === 'edit' && scheduleId) {
+          await editScheduleForm(scheduleId);
+        } else if (action === 'delete' && scheduleId) {
+          await deleteScheduleHandler(scheduleId);
+        } else if (action === 'create') {
+          await createScheduleForm();
+        } else if (action === 'back') {
+          await loadAllSchedules();
+        }
+      });
+  $main.appendChild($target);
+  loadAllSchedules();
+}
+
+async function loadAllSchedules() {
+  const schedules = await getSchedules();
+  renderAllSchedules(schedules);
+}
+
+async function viewSchedule(id) {
+  const schedule = await getScheduleById(id);
+  renderViewSchedule(schedule);
+}
+
+async function createScheduleForm() {
+  renderCreateScheduleForm();
+  document.getElementById('createScheduleForm').addEventListener('submit',
+      async (event) => {
+        event.preventDefault();
+        const content = document.getElementById('content').value;
+        const memberId = document.getElementById('memberId').value;
+        await createSchedule(memberId, {content});
+        await loadAllSchedules();
+      });
+}
+
+async function editScheduleForm(id) {
+  const schedule = await getScheduleById(id);
+  renderEditScheduleForm(schedule);
+
+  document.getElementById('editScheduleForm').addEventListener('submit',
+      async (event) => {
+        event.preventDefault();
+        const content = document.getElementById('content').value;
+        const password = document.getElementById('password').value;
+        await updateSchedule(id, {content, password});
+        await loadAllSchedules();
+      });
+}
+
+async function deleteScheduleHandler(id) {
+  const password = prompt('지우기 위한 비밀번호를 입력해주세요: ');
+  if (!password) {
+    return;
+  }
+  await deleteSchedule(id, {password});
+  await loadAllSchedules();
+}
+

--- a/src/main/resources/static/js/schedule/render.js
+++ b/src/main/resources/static/js/schedule/render.js
@@ -1,0 +1,73 @@
+const TARGET_ID = "schedule";
+
+export function renderAllSchedules(schedules) {
+  const $target = document.getElementById(TARGET_ID);
+  $target.innerHTML = `
+        <h1>All Schedules</h1>
+        <table>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Content</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+          ${schedules.map(schedule =>
+      `<tr class="schedule-item" data-id="${schedule.id}">
+                <td>${schedule.id}</td>
+                <td>${schedule.content}</td>
+                <td>
+                  <button data-action="view">View</button>
+                  <button data-action="edit">Edit</button>
+                  <button data-action="delete">Delete</button>
+                </td>
+              </tr>`).join('')}
+          </tbody>
+        </table>
+      <br/>
+      <button data-action="create">Create New Schedule</button>
+  `;
+}
+
+export function renderViewSchedule(schedule) {
+  const $target = document.getElementById(TARGET_ID);
+  $target.innerHTML = `
+        <h1>View Schedule</h1>
+        <div class="schedule-item" data-id="${schedule.id}">
+            <p>ID: ${schedule.id}</p>
+            <p>Content: ${schedule.content}</p>
+        </div>
+        <br/>
+        <button data-action="back">Back to list</button>`;
+}
+
+export function renderCreateScheduleForm() {
+  const $target = document.getElementById(TARGET_ID);
+  $target.innerHTML = `<h1>Create Schedule</h1>
+        <form id="createScheduleForm">
+            <label for="content">Content:</label>
+            <input type="text" id="content" name="content" required>
+            <label for="memberId">회원 아이디:</label>
+            <input type="text" id="memberId" name="memberId" required>
+            <button type="submit">Create</button>
+        </form>
+        <br/>
+        <button data-action="back">Back to list</button>
+`;
+}
+
+export function renderEditScheduleForm(schedule) {
+  const $target = document.getElementById(TARGET_ID);
+  $target.innerHTML = `<h1>Edit Schedule</h1>
+        <form id="editScheduleForm">
+            <label for="content">Content:</label>
+            <input type="text" id="content" name="content" value="${schedule.content}" required>
+            <label for="password">비밀번호:</label>
+            <input type="password" id="password" name="password" required>
+            <button type="submit">Update</button>
+        </form>
+        <br/>
+        <button data-action="back">Back to list</button>
+`;
+}

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -1,0 +1,24 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+  padding: 0;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 8px;
+  text-align: left;
+  border-bottom: 1px solid #ddd;
+}
+
+th {
+  background-color: #f2f2f2;
+}
+
+button {
+  margin-right: 5px;
+}


### PR DESCRIPTION
## 구현 사항

- Member 엔티티 추가
- Schedule이 Member를 바라보도록 변경
- 테스트를 위한 Ajax 통신을 하는 프론트 JS 파일 작성

## 구현 결과

![ezgif-7-f6bc4fcec0](https://github.com/user-attachments/assets/5a0acf24-3021-4097-b6a1-7f82c6ea167f)


## ERD 설계

```mermaid
erDiagram
Member {
	bigint id PK "고유 식별자"
	varchar name "이름"
	varchar email "이메일"
	varchar password "비밀번호"
	datetime created_at "회원가입 시간"
	datetime updated_at "정보변경 시간"
}

Schedule {
	bigint id PK "고유 식별자"
	bigint member_id FK "멤버 참조"
	varchar content "내용"
	datetime created_at "등록 시간"
	datetime updated_at "수정 시간"
}

Member ||--o{ Schedule : " "
```